### PR TITLE
refactor: use consistent gorm.G syntax for database queries

### DIFF
--- a/handlers/admin/roles.go
+++ b/handlers/admin/roles.go
@@ -51,7 +51,7 @@ func HandleRoleEdit(c *fiber.Ctx) error {
 	roleID := c.Params("id")
 
 	var role models.Role
-	if err := database.DBConn.Where("id = ?", roleID).First(&role).Error; err != nil {
+	if err := gorm.G[models.Role](database.DBConn).Where("id = ?", roleID).First(context.Background(), &role).Error; err != nil {
 		return c.Status(404).SendString("Role not found")
 	}
 
@@ -70,7 +70,7 @@ func HandleRoleCreate(c *fiber.Ctx) error {
 		Description: description,
 	}
 
-	if err := database.DBConn.Create(&role).Error; err != nil {
+	if err := gorm.G[models.Role](database.DBConn).Create(&role).Error; err != nil {
 		// Check for unique constraint violation
 		if isDuplicateKeyError(err) {
 			c.Status(400)
@@ -89,7 +89,7 @@ func HandleRoleUpdate(c *fiber.Ctx) error {
 	roleID := c.Params("id")
 
 	var role models.Role
-	if err := database.DBConn.Where("id = ?", roleID).First(&role).Error; err != nil {
+	if err := gorm.G[models.Role](database.DBConn).Where("id = ?", roleID).First(context.Background(), &role).Error; err != nil {
 		return c.Status(404).SendString("Role not found")
 	}
 
@@ -97,7 +97,7 @@ func HandleRoleUpdate(c *fiber.Ctx) error {
 	role.Slug = c.FormValue("slug")
 	role.Description = c.FormValue("description")
 
-	if err := database.DBConn.Save(&role).Error; err != nil {
+	if err := gorm.G[models.Role](database.DBConn).Save(&role).Error; err != nil {
 		// Check for unique constraint violation
 		if isDuplicateKeyError(err) {
 			c.Status(400)
@@ -115,7 +115,7 @@ func HandleRoleUpdate(c *fiber.Ctx) error {
 func HandleRoleDelete(c *fiber.Ctx) error {
 	roleID := c.Params("id")
 
-	if err := database.DBConn.Delete(&models.Role{}, "id = ?", roleID).Error; err != nil {
+	if err := gorm.G[models.Role](database.DBConn).Delete(&models.Role{}, "id = ?", roleID).Error; err != nil {
 		return c.Status(400).SendString("Error deleting role")
 	}
 

--- a/handlers/admin/users.go
+++ b/handlers/admin/users.go
@@ -99,12 +99,11 @@ func HandleUserCreate(c *fiber.Ctx) error {
 		user.RoleSlug = roleSlug
 	}
 
-	if err := database.DBConn.Create(&user).Error; err != nil {
+	if err := gorm.G[models.User](database.DBConn).Create(&user).Error; err != nil {
 		// Check for unique constraint violation
 		if isDuplicateKeyError(err) {
 			c.Status(400)
-			var roles []models.Role
-			database.DBConn.Order("name ASC").Find(&roles)
+			roles, _ := gorm.G[models.Role](database.DBConn).Order("name ASC").Find(context.Background())
 			vm := viewmodels.NewUserFormViewModel(&user, roles, false)
 			vm.FormErrors["email"] = "A user with this email already exists"
 			return handlerutils.RenderNode(c, adminviews.UserFormModal(vm))
@@ -120,7 +119,7 @@ func HandleUserUpdate(c *fiber.Ctx) error {
 	userID := c.Params("id")
 
 	var user models.User
-	if err := database.DBConn.Where("id = ?", userID).First(&user).Error; err != nil {
+	if err := gorm.G[models.User](database.DBConn).Where("id = ?", userID).First(context.Background(), &user).Error; err != nil {
 		return c.Status(404).SendString("User not found")
 	}
 
@@ -143,12 +142,11 @@ func HandleUserUpdate(c *fiber.Ctx) error {
 		user.RoleSlug = ""
 	}
 
-	if err := database.DBConn.Save(&user).Error; err != nil {
+	if err := gorm.G[models.User](database.DBConn).Save(&user).Error; err != nil {
 		// Check for unique constraint violation
 		if isDuplicateKeyError(err) {
 			c.Status(400)
-			var roles []models.Role
-			database.DBConn.Order("name ASC").Find(&roles)
+			roles, _ := gorm.G[models.Role](database.DBConn).Order("name ASC").Find(context.Background())
 			vm := viewmodels.NewUserFormViewModel(&user, roles, true)
 			vm.FormErrors["email"] = "A user with this email already exists"
 			return handlerutils.RenderNode(c, adminviews.UserFormModal(vm))
@@ -163,7 +161,7 @@ func HandleUserUpdate(c *fiber.Ctx) error {
 func HandleUserDelete(c *fiber.Ctx) error {
 	userID := c.Params("id")
 
-	if err := database.DBConn.Delete(&models.User{}, "id = ?", userID).Error; err != nil {
+	if err := gorm.G[models.User](database.DBConn).Delete(&models.User{}, "id = ?", userID).Error; err != nil {
 		return c.Status(400).SendString("Error deleting user")
 	}
 
@@ -179,8 +177,7 @@ func renderUserTable(c *fiber.Ctx) error {
 // buildUserTableData fetches users from database and builds table data
 func buildUserTableData() *admincomponents.TableData {
 	// Fetch users from database
-	var users []models.User
-	database.DBConn.Preload("Role").Order("email ASC").Find(&users)
+	users, _ := gorm.G[models.User](database.DBConn).Preload("Role").Order("email ASC").Find(context.Background())
 
 	// Build table data
 	userTableData := &admincomponents.TableData{


### PR DESCRIPTION
Replace old database.DBConn.* queries with gorm.G[Model] pattern for consistency.

This converts:
- database.DBConn.Create(&model) -> gorm.G[Model](database.DBConn).Create(&model)
- database.DBConn.Where().First(&model) -> gorm.G[Model](database.DBConn).Where().First(ctx, &model)
- database.DBConn.Save(&model) -> gorm.G[Model](database.DBConn).Save(&model)
- database.DBConn.Delete() -> gorm.G[Model](database.DBConn).Delete()
- database.DBConn.Preload().Find() -> gorm.G[Model](database.DBConn).Preload().Find(ctx)

Affected files:
- handlers/admin/users.go
- handlers/admin/roles.go